### PR TITLE
Adding provision for passing rejectUnauthorized to the wrapper

### DIFF
--- a/lib/zabbix.js
+++ b/lib/zabbix.js
@@ -1,11 +1,13 @@
 var request = require('request');
 
-var Client = function(url, user, password) {
+var Client = function(url, user, password, options) {
+  options = options || {};
   this.url = url;
   this.user = user;
   this.password = password;
   this.id = 0;
   this.auth = null;
+  this.rejectUnauthorized = options.rejectUnauthorized;
 };
 
 Client.prototype.call = function(method, params, callback) {
@@ -61,6 +63,7 @@ Client.prototype._request = function(method, params, callback) {
   request.post({
     uri: this.url,
     headers: { 'content-type': 'application/json-rpc' },
+    rejectUnauthorized: this.rejectUnauthorized,
     body: JSON.stringify(body)},
   function(error, resp, body) {
     callback(error, resp, body);


### PR DESCRIPTION
The constructor now accepts an optional `options` argument, that is an object containing extra options to be passing to request. Currently, only `rejectUnauthorized` is supported.